### PR TITLE
Make appWasBackgroundedOnExist a visible property

### DIFF
--- a/TBOOMDetector/TBOOMDetector.h
+++ b/TBOOMDetector/TBOOMDetector.h
@@ -25,6 +25,7 @@ typedef NS_ENUM(NSInteger, TBTerminationType) {
 @interface TBOOMDetector : NSObject
 
 @property (nonatomic, readonly) TBTerminationType lastTerminationType;
+@property (nonatomic, readonly) BOOL appWasBackgroundedOnExit;
 
 - (instancetype)initWithCrashlyticsApiKey:(NSString*)apiKey
                                 directory:(NSString*)directory

--- a/TBOOMDetector/TBOOMDetector.m
+++ b/TBOOMDetector/TBOOMDetector.m
@@ -15,7 +15,6 @@
   NSString *backgroundStateFile;
   NSString *terminationEventFileContents;
   BOOL crashWasDetected;
-  BOOL appWasBackgroundedOnExit;
   NSString *stateDirectory;
 }
 
@@ -63,10 +62,10 @@ static NSString *OSVersionKey = @"OSVersion";
     }
     
     backgroundStateFile = [directory stringByAppendingString:@"OOMDetectorBackgroundState.bool"];
-    appWasBackgroundedOnExit = NO;
+    _appWasBackgroundedOnExit = NO;
     if([[NSFileManager defaultManager] fileExistsAtPath:backgroundStateFile]) {
       [[NSFileManager defaultManager] removeItemAtPath:backgroundStateFile error:nil];
-      appWasBackgroundedOnExit = YES;
+      _appWasBackgroundedOnExit = YES;
     }
     
     //Wait for crashlytics to run, so we know if there was a crash
@@ -103,7 +102,7 @@ static NSString *OSVersionKey = @"OSVersion";
   } else if ([terminationEventFileContents isEqualToString:@"debugger"]) {
     terminationType = TBTerminationTypeDebugger;
   } else {
-    if(appWasBackgroundedOnExit) {
+    if(_appWasBackgroundedOnExit) {
       NSLog(@"Detected Background OOM");
       terminationType = TBTerminationTypeBackgroundOom;
     } else {


### PR DESCRIPTION
This is useful to show messaging in app, before crashlytics has loaded
to determine what type of crash it was.