### PR TITLE
Fix wrong path for backgroundStateFile

### DIFF
--- a/TBOOMDetector/TBOOMDetector.m
+++ b/TBOOMDetector/TBOOMDetector.m
@@ -61,7 +61,7 @@ static NSString *OSVersionKey = @"OSVersion";
       [self logTerminationEvent:@"debugger"];
     }
     
-    backgroundStateFile = [directory stringByAppendingString:@"OOMDetectorBackgroundState.bool"];
+    backgroundStateFile = [directory stringByAppendingPathComponent:@"OOMDetectorBackgroundState.bool"];
     _appWasBackgroundedOnExit = NO;
     if([[NSFileManager defaultManager] fileExistsAtPath:backgroundStateFile]) {
       [[NSFileManager defaultManager] removeItemAtPath:backgroundStateFile error:nil];

--- a/demo/demo/AppDelegate.m
+++ b/demo/demo/AppDelegate.m
@@ -10,19 +10,18 @@
 #import "TBOOMDetector.h"
 
 @interface AppDelegate ()
-
+@property (nonatomic, retain) TBOOMDetector *oomDetector;
 @end
 
 @implementation AppDelegate
 
-
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   NSArray *paths = NSSearchPathForDirectoriesInDomains (NSLibraryDirectory, NSUserDomainMask, YES);
-  TBOOMDetector *oomDetector = [[TBOOMDetector alloc] initWithCrashlyticsApiKey:@""
-                                                                      directory:paths[0]
-                                                                       callback:^(TBTerminationType terminationType) {
-                                                                         NSLog(@"Termination type %li", (long)terminationType);
-                                                                       }];
+  self.oomDetector = [[TBOOMDetector alloc] initWithCrashlyticsApiKey:@""
+                                                            directory:paths[0]
+                                                             callback:^(TBTerminationType terminationType) {
+                                                               NSLog(@"Termination type %li", (long)terminationType);
+                                                             }];
   return YES;
 }
 


### PR DESCRIPTION
This is causing problem on device that falsely log BackgroundOom as ForegroundOom.

In the demo AppDelegate, you setup the path using `Library` directory, like this...
```
  NSArray *paths = NSSearchPathForDirectoriesInDomains (NSLibraryDirectory, NSUserDomainMask, YES);
  TBOOMDetector *oomDetector = [[TBOOMDetector alloc] initWithCrashlyticsApiKey:@""
                                                                      directory:paths[0]
                                                                       callback:^(TBTerminationType terminationType) {
                                                                         NSLog(@"Termination type %li", (long)terminationType);
                                                                       }];
```

In TBOOMDetector.m, `backgroundStateFile` is setup like this...
```
backgroundStateFile = [directory stringByAppendingString:@"OOMDetectorBackgroundState.bool"];
```

which creates a path like: `/var/mobile/Containers/Data/Application/8759D5A2-C62F-494C-9E71-D9B3349EA28E/LibraryOOMDetectorBackgroundState.bool`
which points to a file **next to** the Library folder, not inside. And on device, this path is unwritable.
It should be `stringByAppendingPathComponent` instead.
This works fine in Simulator because the same directory has different restrictions.

Also another issue, the `oomDetector` object in AppDelegate is not retained. I created a fix for it.