### PR TITLE
Update podspec

### DIFF
--- a/TBOOMDetector.podspec
+++ b/TBOOMDetector.podspec
@@ -19,5 +19,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/trailbehind/TBOOMDetector.git", :tag => "0.6" }
 
   s.source_files  = "TBOOMDetector/*.{h,m,c}"
+  s.dependency 'Crashlytics', '~> 3'
+  s.static_framework = true
 
 end

--- a/TBOOMDetector.podspec
+++ b/TBOOMDetector.podspec
@@ -19,6 +19,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/trailbehind/TBOOMDetector.git", :tag => "0.6" }
 
   s.source_files  = "TBOOMDetector/*.{h,m,c}"
-  s.dependency 'Crashlytics', '~> 3'
 
 end


### PR DESCRIPTION
Adding `s.static_framework = true` to the podspec allows us to enable `use_frameworks!` and still build this properly.